### PR TITLE
add preview deployment workflow for pull requests

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,115 @@
+name: Preview Deployment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy Preview
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Deploy Preview
+        id: deploy
+        run: |
+          output=$(pnpm sst deploy --stage pr-${{ github.event.pull_request.number }} 2>&1) || true
+          echo "$output"
+          url=$(echo "$output" | grep -oP 'url:\s*\K\S+' || true)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment Preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            const body = url
+              ? `### Preview Deployment\n\n🔗 **Preview URL:** ${url}\n\nThis preview will be automatically torn down when the PR is closed.`
+              : `### Preview Deployment\n\n⚠️ Deployment completed but could not extract preview URL. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`;
+
+            // Find existing bot comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('### Preview Deployment')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  teardown:
+    name: Teardown Preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Remove Preview
+        run: pnpm sst remove --stage pr-${{ github.event.pull_request.number }}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -8,17 +8,25 @@ export default $config({
       home: "aws",
       providers: {
         aws: { region: "eu-west-2" },
-        cloudflare: "5.49.1",
+        ...(input?.stage === "production" ? { cloudflare: "5.49.1" } : {}),
       },
     };
   },
   async run() {
-    new sst.aws.Astro("site-v2", {
-      domain: {
-        name: "haydonlam.com",
-        redirects: ["www.haydonlam.com"],
-        dns: sst.cloudflare.dns(),
-      },
+    const site = new sst.aws.Astro("site-v2", {
+      ...($app.stage === "production"
+        ? {
+            domain: {
+              name: "haydonlam.com",
+              redirects: ["www.haydonlam.com"],
+              dns: sst.cloudflare.dns(),
+            },
+          }
+        : {}),
     });
+
+    return {
+      url: site.url,
+    };
   },
 });


### PR DESCRIPTION
- Create preview.yml workflow triggered on PR open/sync/close
- Deploy to isolated SST stage (pr-<number>) on PR open
- Auto teardown via `sst remove` when PR is closed
- Post preview URL as a comment on the PR
- Conditionally skip Cloudflare provider and domain config for
  non-production stages so previews use the raw AWS URL

https://claude.ai/code/session_01GZpe9bSfPveuqwHaPDoLex