### PR TITLE
Replace hero section with bold name display

### DIFF
--- a/src/components/Home.astro
+++ b/src/components/Home.astro
@@ -26,14 +26,8 @@ import PersonalityType from './home/PersonalityType.astro';
   <HeaderSpacer />
   <section class="h-[768px] max-sm:h-[500px] w-full grid place-items-center">
     <div class="clamped">
-      <div
-        class="relative flex flex-col items-start justify-center translate-y-[-45px]
-        max-sm:items-start"
-      >
-        <p class="text-muted-foreground">Welcome, I&apos;m Haydon</p>
-        <h1 class="text-center max-sm:hidden">Fullstack Software Engineer</h1>
-        <h1 class="text-center max-sm:hidden">based in London.</h1>
-        <h1 class="min-sm:hidden">Fullstack Software Engineer based in London.</h1>
+      <div class="relative flex flex-col items-start justify-center translate-y-[-45px]">
+        <h1 class="font-bold">Haydon Lam</h1>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Strip the hero down to just "Haydon Lam" in bold display font,
removing the subtitle and role description for a cleaner, more
timeless look.

https://claude.ai/code/session_01Fytntq4mNGZdhkthGySQVX