### PR TITLE
Align experiments page layout with photos page

### DIFF
--- a/src/layouts/ExperimentPageLayout.astro
+++ b/src/layouts/ExperimentPageLayout.astro
@@ -2,13 +2,15 @@
 import Header from '@components/_shared/Header.astro';
 import Layout from './Layout.astro';
 import HeaderSpacer from '@components/_shared/HeaderSpacer.astro';
+import HeaderBackdrop from '@components/_shared/HeaderBackdrop.astro';
 ---
 
 <Layout>
-  <main class="bg-yellow-100 flex items-center flex-col">
+  <main class="w-full min-h-full flex flex-col items-center bg-muted-background">
     <Header>
       <h1>Experiments</h1>
     </Header>
+    <HeaderBackdrop class="bg-gradient-to-b from-muted-background opacity-80" />
     <HeaderSpacer />
     <slot />
   </main>

--- a/src/pages/experiments/index.astro
+++ b/src/pages/experiments/index.astro
@@ -5,16 +5,22 @@ const pages: { url: string }[] = Object.values(import.meta.glob('./*.astro', { e
 ---
 
 <ExperimentPageLayout>
-  <ul class="flex p-2 flex-wrap gap-2 justify-around">
-    {
-      pages.map((page) => {
-        const labelFromUrl = page.url.replace('/experiments/', '');
-        return (
-          <li>
-            <a href={page.url}>{labelFromUrl}</a>
-          </li>
-        );
-      })
-    }
-  </ul>
+  <section class="pb-12">
+    <div class="clamped">
+      <ul>
+        {
+          pages.map((page) => {
+            const labelFromUrl = page.url.replace('/experiments/', '');
+            return (
+              <li>
+                <a href={page.url}>
+                  <h2>{labelFromUrl}</h2>
+                </a>
+              </li>
+            );
+          })
+        }
+      </ul>
+    </div>
+  </section>
 </ExperimentPageLayout>


### PR DESCRIPTION
- Update ExperimentPageLayout to use bg-muted-background, HeaderBackdrop
  with gradient, and matching main element classes from photos page
- Wrap experiments index content in section > div.clamped for consistent
  max-width and padding
- Use h2 elements for experiment links to match photos list style

https://claude.ai/code/session_01TgqCWpPih6aciZ9mVzaYDf