### PR TITLE
fix: unlock SST before preview deploy to clear stale locks from cancelled runs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,6 +40,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
+      - name: Unlock SST (clear any stale lock from cancelled runs)
+        run: pnpm sst unlock --stage pr-${{ github.event.pull_request.number }} || true
+
       - name: Deploy Preview
         id: deploy
         run: |


### PR DESCRIPTION
When a concurrent run is cancelled mid-deployment, SST leaves a state lock
behind. The next run then fails with "A concurrent update was detected".

Adding an `sst unlock` step before each deploy clears any stale lock left
by a previously cancelled workflow, so deployments can proceed cleanly.

https://claude.ai/code/session_01477h7Ap5ob4VF1vEBEURTr