### PR TITLE
Refactor Lightbox to use conditional rendering instead of open prop

### DIFF
--- a/src/components/photos/Image.svelte
+++ b/src/components/photos/Image.svelte
@@ -96,7 +96,9 @@
   </div>
 {/if}
 
-<Lightbox src={fullRes.url} {onclose} open={Boolean(isActive && fullRes)} />
+{#if isActive && fullRes}
+  <Lightbox src={fullRes.url} {onclose} />
+{/if}
 
 <style>
   .photo-item {

--- a/src/components/photos/Lightbox.svelte
+++ b/src/components/photos/Lightbox.svelte
@@ -1,23 +1,19 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { panZoomCanvas } from './panZoomCanvas';
 
   let {
     src,
-    onclose,
-    open = false
-  }: { src: string; onclose: () => void; open: boolean } = $props();
+    onclose
+  }: { src: string; onclose: () => void } = $props();
 
   let isLoading = $state(true);
   let hasError = $state(false);
 
   let dialog = $state<HTMLDialogElement | undefined>(undefined);
 
-  $effect(() => {
-    if (open) {
-      dialog?.showModal();
-    } else {
-      dialog?.close();
-    }
+  onMount(() => {
+    dialog?.showModal();
   });
 </script>
 
@@ -56,11 +52,10 @@
   .lightbox {
     all: unset;
     @apply fixed inset-0 w-screen h-screen max-w-screen max-h-screen overflow-hidden bg-background/90 shadow-2xl;
-    @apply transition-all duration-400 transition-discrete ease-in;
+    @apply transition-all duration-400 ease-out;
 
-    @apply translate-y-full scale-95;
-    @apply open:translate-0 scale-100;
-    @apply starting:open:translate-y-full starting:scale-95;
+    @apply open:translate-y-0 open:scale-100;
+    @apply starting:open:translate-y-full starting:open:scale-95;
   }
 
   .lightbox::backdrop {


### PR DESCRIPTION
## Summary
Refactored the Lightbox component to use conditional rendering for opening/closing behavior instead of relying on an `open` prop and reactive effects. This simplifies the component API and improves the declarative nature of the code.

## Key Changes
- Removed the `open` prop from Lightbox component and replaced reactive effect with `onMount` hook
- Changed Image component to conditionally render Lightbox only when active and fullRes image is available
- Simplified dialog state management by removing the need to track open/close state externally
- Updated Lightbox CSS transitions to use `open:` pseudo-class selectors more consistently
- Removed `transition-discrete` class and changed easing from `ease-in` to `ease-out` for smoother animations

## Implementation Details
- The Lightbox now automatically opens on mount via `onMount` hook, eliminating the need for external state management
- The parent Image component controls Lightbox visibility through conditional rendering (`{#if isActive && fullRes}`)
- CSS transitions now rely on the native `<dialog>` element's `open` attribute state rather than custom prop-based logic
- This approach is more idiomatic to Svelte's reactive model and reduces prop drilling

https://claude.ai/code/session_01JzPepaLiputC5V6kMXyzbE